### PR TITLE
Make code compliant to strict mode.

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -7,7 +7,7 @@ function ValidationError(param, message) {
   this.param = param
   this.name = "Invalid arguments"
   this.message = param + " " + message
-  Error.captureStackTrace(this, arguments.callee);
+  Error.captureStackTrace(this, ValidationError);
 }
 ValidationError.prototype = new Error
 
@@ -26,7 +26,7 @@ function MultipleValidationError(param, errors) {
   details.unshift("Validations failed for keys: " + this.params.join(' '))
   this.message = details.join("\n")
   this.errors = errors
-  Error.captureStackTrace(this, arguments.callee);
+  Error.captureStackTrace(this, MultipleValidationError);
 }
 MultipleValidationError.prototype = new ValidationError
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Library to speak the memcache text protocol",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/tap $(find test -iname '*.test.js')"
+    "test": "./node_modules/.bin/tap --strict $(find test -iname '*.test.js')"
   },
   "repository": "",
   "author": "",
@@ -13,6 +13,6 @@
     "callback-timeout": "~0.1.0"
   },
   "devDependencies": {
-    "tap": "~0.4.2"
+    "tap": "~10.7.0"
   }
 }

--- a/test/integration/cas.test.js
+++ b/test/integration/cas.test.js
@@ -4,7 +4,7 @@ var MemcacheClient = require('../../lib/memcacheclient')
 
 test("can use cas with memcache", function(t) {
   var server = new MemcacheServer()
-  var client = new MemcacheClient({ servers: [ server.host ] })
+  var client = new MemcacheClient({ servers: [ server.host ], unref: false })
 
   client.flush(0, function(err, result) {
     t.error(err, "should get no error")
@@ -37,6 +37,7 @@ test("can use cas with memcache", function(t) {
     client.flush(0, function(err, result) {
       t.error(err, "should get no error")
       t.equals(result, "OK", "should get result OK for a FLUSH")
+      client.end()
       server.end()
       t.end()
     })

--- a/test/integration/disconnect.test.js
+++ b/test/integration/disconnect.test.js
@@ -11,7 +11,7 @@ test("can talk to memcache", function(t) {
     t.end()
     return
   }
-  var client = new MemcacheClient({ servers: [server.host] })
+  var client = new MemcacheClient({ servers: [server.host], unref: false })
 
   client.flush(0, function(err, result) {
     t.error(err, "should get no error")


### PR DESCRIPTION
tap was also updated because the old one uses octal expressions which fails in strict mode.